### PR TITLE
Fix keyToggle does not release key

### DIFF
--- a/src/keypress.c
+++ b/src/keypress.c
@@ -96,11 +96,6 @@ void win32KeyEvent(int key, MMKeyFlags flags)
 		}
 	}
 
-	/* Set the scan code for keyup */
-	if ( flags & KEYEVENTF_KEYUP ) {
-		scan |= 0x80;
-	}
-
 	flags |= KEYEVENTF_SCANCODE;
 
 	INPUT keyboardInput;


### PR DESCRIPTION
After certain key is toggled by `keyToggle('w', 'down')` , the key keeps getting pressed even after the `keyToggle('w', 'up')` gets called. The issue mainly occurred in some software, mainly games.

Based on comments on https://github.com/octalmage/robotjs/issues/252 and https://github.com/nut-tree/libnut-core/pull/87, removing the scan code for keyup event solve this certain issue.

The softwares (games) that have been tested:
- Monster Hunter World
- Monster Hunter Rise
- The Witcher 3