### PR TITLE
Fix npm link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center"><img src="https://cldup.com/1ATDf2JMtv.png"></p>
 
 [![Build all versions and publish to NPM](https://github.com/hurdlegroup/robotjs/actions/workflows/build-all.yml/badge.svg)](https://github.com/hurdlegroup/robotjs/actions/workflows/build-all.yml)
-<a href="https://www.npmjs.com/package/robotjs"><img src="https://img.shields.io/npm/v/@hurdlegroup/robotjs.svg"></a>
+<a href="https://www.npmjs.com/package/@hurdlegroup/robotjs"><img src="https://img.shields.io/npm/v/@hurdlegroup/robotjs.svg"></a>
 
 > Node.js Desktop Automation. Control the mouse, keyboard, and read the screen.
 


### PR DESCRIPTION
The npm image in the readme still links to `robotjs` on npm. Fix it to link to `@hurdlegroup/robotjs`.